### PR TITLE
Publish wheels to PyPI on deploy.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,10 @@ script:
   - pytest
 deploy:
   - provider: pypi
+    distributions: "sdist bdist_wheel"
     user: shntnu
     on:
       tags: true
-      distributions: "sdist bdist_wheel"
       repo: cytomining/cytominer-database
     skip_cleanup: true
     password:


### PR DESCRIPTION
Resolves #54 

It appears that only source distributions are published to PyPI. This is likely because `distributions` is nested under `on`, which appears to be incorrect: https://docs.travis-ci.com/user/deployment/pypi/#Uploading-different-distributions

We'll find out!