### PR TITLE
Release 0.0.1b2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ deploy:
     on:
       tags: true
       repo: cytomining/cytominer-database
+      python: "3.5"
     skip_cleanup: true
     password:
       secure: CpXjKwUeDNx2GsvZwL13TmrMhv2JuapqPcsq+OhUL/1odXTmBi0iCsEUQE3XXbAJfZC7phpLLOnwqsVZZKyWGgbMovJJEL/APB2xNqsPFggO0jY/ql8Av/2xkMfR5monAtSyDYBDytb+c5JLv+qyHt4+XfpK3goxGyWXJt8DpcbRdujFMpC2hL5PDoyJEOoccTC8UCf9CMAQoyRkfiyXYe4DPL3J2rxquIs5gMFthISO9Hvjup1ABebuIqBkYufxRyLfv4lENpqUfgOlJN3N0RbhMwo/EqHsnkkjT7FoAzSvcfQLVGQJSdlumxSZf4H34EkAgXiXuxgOfjo1rT2umtr0fcqvjklbm0rjJMKfj3CM09rtwZT9GlyBCe1+fgHGoz/MuMOFpA2dTiUnGl12pFfBYow4hQ5kvu4FWstMLQydlwouTNK+FNQNy+bPr+kfsEeY7aDu8eRwnZ29pWCFgWP/yWeCLwfEEVPVT74xktYnZrdWUZYDgrUpKwZ/YW6bO62ndE/KzIwb8UFVW4DCFAv93BOlDE85Ah5IOOOjvrsw5/8m1DdTr9x1TzHG6R8xUoVgd0+3ky8HS/5WUZvB9iTgJYbw1SmzRJ14o9Or2yApLMOiIAUlFQSphB2mpI8ajW8QunLTIxmSFrnGKvryDv2sFSjUAKAaxjyfsIimJwM=

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,6 @@
+# Contributors
+
+cytominer-database initially developed by
+- [Allen Goodman](https://github.com/0x00b1/)
+- [Claire McQuin](https://github.com/mcquin/)
+- [Shantanu Singh](https://github.com/shntnu/)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
---index-url https://pypi.python.org/simple/
-
--e .

--- a/requirements_doc.txt
+++ b/requirements_doc.txt
@@ -1,0 +1,2 @@
+sphinx>=1.6.4
+sphinx_rtd_theme>=0.2.5b1

--- a/setup.py
+++ b/setup.py
@@ -3,17 +3,9 @@ import setuptools
 
 setuptools.setup(
     name='cytominer_database',
-    version='0.0.1b1',
-    author=[
-        'Allen Goodman',
-        "Claire McQuin",
-        "Shantanu Singh"
-    ],
-    author_email=[
-        "allen.goodman@icloud.com",
-        "mcquincl@gmail.com",
-        "shsingh@broadinstitute.org"
-    ],
+    version='0.0.1b2',
+    author="Shantanu Singh",
+    author_email="shsingh@broadinstitute.org",
     entry_points="""
     [console_scripts]
     cytominer-database=cytominer_database.command:command

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,10 @@
 import setuptools
 
 
+with open("requirements_doc.txt", "r") as f:
+    doc_requirements = f.read().splitlines()
+
+
 setuptools.setup(
     name='cytominer_database',
     version='0.0.1b2',
@@ -13,9 +17,7 @@ setuptools.setup(
     extras_require={
         "dev": [
             "pytest>=3.2.2",
-            "sphinx>=1.6.3",
-            "sphinx_rtd_theme>=0.2.5b1"
-        ]
+        ] + doc_requirements
     },
     long_description="cytominer-database provides mechanisms to import CSV "
                      "files generated in a morphological profiling experiment "


### PR DESCRIPTION
- PyPI only supports one `author`/`author_email`. I propose using @shntnu as the primary author. Additional contributors are noted in `CONTRIBUTING.md`
- RTD makes use of requirements files. We moved the documentation requirements to `requirements_doc.txt` so that RTD can build with the pip installable theme.