### PR TITLE
Add requirements file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ addons:
 cache:
   - pip
 install:
-  - pip install --upgrade --editable .[dev]
+  - pip install --upgrade -r requirements.txt
 language:
   - python
 python:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ environment:
     - PYTHON: "C:\\Python36-x64"
 
 install:
-   - "%PYTHON%\\python.exe -m pip install --upgrade --editable .[dev]"
+   - "%PYTHON%\\python.exe -m pip install --upgrade -r requirements.txt"
 
 build: off
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+--index-url https://pypi.python.org/simple/
+
+--editable .
+
+pytest>=3.2.2
+sphinx>=1.6.4
+sphinx_rtd_theme>=0.2.5b1

--- a/requirements_doc.txt
+++ b/requirements_doc.txt
@@ -1,2 +1,0 @@
-sphinx>=1.6.4
-sphinx_rtd_theme>=0.2.5b1

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,6 @@
 import setuptools
 
 
-with open("requirements_doc.txt", "r") as f:
-    doc_requirements = f.read().splitlines()
-
-
 setuptools.setup(
     name='cytominer_database',
     version='0.0.1b2',
@@ -14,11 +10,6 @@ setuptools.setup(
     [console_scripts]
     cytominer-database=cytominer_database.command:command
     """,
-    extras_require={
-        "dev": [
-            "pytest>=3.2.2",
-        ] + doc_requirements
-    },
     long_description="cytominer-database provides mechanisms to import CSV "
                      "files generated in a morphological profiling experiment "
                      "into a database backend. "


### PR DESCRIPTION
Resolves #71 

The automated readthedocs build failed due to uninstalled dependencies. Adding documentation and test dependencies to the requirements file allows us to specify the build requirements in setup.py's `install_requirements` while also provide readthedocs with a requirements.txt

```
Running Sphinx v1.6.4
making output directory...
loading translations [en]... done
loading pickled environment... not yet created
building [mo]: targets for 0 po files that are out of date
building [readthedocs]: targets for 3 source files that are out of date
updating environment: 3 added, 0 changed, 0 removed
reading sources... [ 33%] cytominer_database
reading sources... [ 66%] index
reading sources... [100%] modules

WARNING: /home/docs/checkouts/readthedocs.org/user_builds/cytominer-database/checkouts/release-0.0.1b2/doc/cytominer_database.rst:10: (WARNING/2) autodoc: failed to import module u'cytominer_database.ingest'; the following exception was raised:
Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/cytominer-database/envs/release-0.0.1b2/local/lib/python2.7/site-packages/sphinx/ext/autodoc.py", line 658, in import_object
    __import__(self.modname)
  File "/home/docs/checkouts/readthedocs.org/user_builds/cytominer-database/checkouts/release-0.0.1b2/cytominer_database/ingest.py", line 41, in <module>
    import backports.tempfile
ImportError: No module named backports.tempfile
WARNING: /home/docs/checkouts/readthedocs.org/user_builds/cytominer-database/checkouts/release-0.0.1b2/doc/cytominer_database.rst:18: (WARNING/2) autodoc: failed to import module u'cytominer_database.utils'; the following exception was raised:
Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/cytominer-database/envs/release-0.0.1b2/local/lib/python2.7/site-packages/sphinx/ext/autodoc.py", line 658, in import_object
    __import__(self.modname)
  File "/home/docs/checkouts/readthedocs.org/user_builds/cytominer-database/checkouts/release-0.0.1b2/cytominer_database/utils.py", line 7, in <module>
    import csvkit.utilities.csvclean
ImportError: No module named csvkit.utilities.csvclean
```

See also [setup.py vs requirements.txt](https://caremad.io/posts/2013/07/setup-vs-requirement/).

I have updated the readthedocs configuration to use "requirements.txt" instead of "requirements_doc.txt". I will update the repository instructions, too.