### PR TITLE
Hide FutureWarnings from the user.

### DIFF
--- a/cytominer_database/command.py
+++ b/cytominer_database/command.py
@@ -1,10 +1,16 @@
 import os
 import sys
+import warnings
 
 import click
 
 
 class Command(click.MultiCommand):
+    def __init__(self):
+        super(Command, self).__init__()
+
+        warnings.simplefilter(action="ignore", category=FutureWarning)
+
     def list_commands(self, context):
         rv = []
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ universal=1
 
 [tool:pytest]
 addopts =
-    -v
+    -v -Wd
 minversion =
     3.0.2
 testpaths =

--- a/tests/commands/test_command_ingest.py
+++ b/tests/commands/test_command_ingest.py
@@ -47,7 +47,8 @@ def test_run(dataset, runner):
 
         config = configparser.ConfigParser()
 
-        config.read(config_file)
+        with open(config_file, "r") as config_fd:
+            config.read_file(config_fd)
 
         for (k, v) in dict({"cells": "Cells.csv", "cytoplasm": "Cytoplasm.csv", "nuclei": "Nuclei.csv"}).items():
             config["filenames"][k] = v


### PR DESCRIPTION
Resolves #69 

Hide FutureWarnings, including those generated by dependencies of dependencies, from the command line.

```
> cytominer-database --help
Usage: cytominer-database [OPTIONS] COMMAND [ARGS]...

Options:
  --help  Show this message and exit.

Commands:
  ingest  Import CSV files into a database.
```

Re-enables warnings during tests. See: https://docs.python.org/2/library/warnings.html#updating-code-for-new-versions-of-python

Bonus: resolved a warning