### PR TITLE
Make only a single database connection and close it when you're done with it.

### DIFF
--- a/cytominer_database/ingest.py
+++ b/cytominer_database/ingest.py
@@ -93,7 +93,6 @@ def into(input, output, name, identifier, con, skip_table_prefix=False):
         table_number_column = [identifier] * number_of_rows  # create additional column
         df.insert(0, "TableNumber", table_number_column, allow_duplicates=False)
         df.to_sql(name=name, con=con, if_exists="append", index=False)
-        con.close()
 
 
 def checksum(pathname, buffer_size=65536):

--- a/cytominer_database/ingest.py
+++ b/cytominer_database/ingest.py
@@ -59,7 +59,7 @@ def __format__(name, header):
     return "{}_{}".format(name, header)
 
 
-def into(input, output, name, identifier, skip_table_prefix=False):
+def into(input, output, name, identifier, con, skip_table_prefix=False):
     """Ingest a CSV file into a table in a database.
 
     :param input: Input CSV file.
@@ -76,8 +76,6 @@ def into(input, output, name, identifier, skip_table_prefix=False):
         #   /usr/local/lib/python3.6/site-packages/odo/utils.py:128: DeprecationWarning: inspect.getargspec() is
         #     deprecated, use inspect.signature() or inspect.getfullargspec()
         warnings.simplefilter("ignore", category=DeprecationWarning)
-        engine = create_engine(output, poolclass=NullPool)
-        con = engine.connect()
 
         df = pd.read_csv(input)
         # add "name" prefix to column headers
@@ -133,6 +131,9 @@ def seed(source, target, config_path, skip_image_prefix=True):
 
     # list the subdirectories that contain CSV files
     directories = sorted(list(cytominer_database.utils.find_directories(source)))
+    
+    engine = create_engine(output, poolclass=NullPool)
+    con = engine.connect()
 
     for directory in directories:
         # get the image CSV and the CSVs for each of the compartments
@@ -160,6 +161,7 @@ def seed(source, target, config_path, skip_image_prefix=True):
                 output=target,
                 name=name.capitalize(),
                 identifier=identifier,
+                con=con,
                 skip_table_prefix=skip_image_prefix,
             )
         except sqlalchemy.exc.DatabaseError as e:
@@ -175,4 +177,6 @@ def seed(source, target, config_path, skip_image_prefix=True):
                 output=target,
                 name=name.capitalize(),
                 identifier=identifier,
+                con=con,
             )
+    con.close()

--- a/cytominer_database/ingest.py
+++ b/cytominer_database/ingest.py
@@ -132,7 +132,7 @@ def seed(source, target, config_path, skip_image_prefix=True):
     # list the subdirectories that contain CSV files
     directories = sorted(list(cytominer_database.utils.find_directories(source)))
     
-    engine = create_engine(output, poolclass=NullPool)
+    engine = create_engine(target, poolclass=NullPool)
     con = engine.connect()
 
     for directory in directories:

--- a/cytominer_database/ingest.py
+++ b/cytominer_database/ingest.py
@@ -47,6 +47,7 @@ import pandas as pd
 import backports.tempfile
 import sqlalchemy.exc
 from sqlalchemy import create_engine
+from sqlalchemy.pool import NullPool
 
 import cytominer_database.utils
 
@@ -75,7 +76,7 @@ def into(input, output, name, identifier, skip_table_prefix=False):
         #   /usr/local/lib/python3.6/site-packages/odo/utils.py:128: DeprecationWarning: inspect.getargspec() is
         #     deprecated, use inspect.signature() or inspect.getfullargspec()
         warnings.simplefilter("ignore", category=DeprecationWarning)
-        engine = create_engine(output)
+        engine = create_engine(output, poolclass=NullPool)
         con = engine.connect()
 
         df = pd.read_csv(input)
@@ -94,6 +95,7 @@ def into(input, output, name, identifier, skip_table_prefix=False):
         table_number_column = [identifier] * number_of_rows  # create additional column
         df.insert(0, "TableNumber", table_number_column, allow_duplicates=False)
         df.to_sql(name=name, con=con, if_exists="append", index=False)
+        con.close()
 
 
 def checksum(pathname, buffer_size=65536):


### PR DESCRIPTION
For cases with more than a few hundred CSVs, in 0.3.3 we've been getting SQLite writing failures with variants of `OSError: [Errno 24] Too many open files: '/tmp/tmpyzcy0lbx'` . This seems to be due to that, when we moved to SQAlchemy from odo, connection generation was added without closing, and it was .  

I've tested both creating the connections from a null pool and then closing the connections a) just where they were, in `into`, and b) once per set, in `seed`; the latter seems to be about 5% faster, so that's the change I'm looking to pull, but if for whatever reason we want to do it inside `into` in the future that seems to be also fine!