### PR TITLE
Remove `backports.tempfile` for Python compatibility and bump version

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -26,5 +26,5 @@ authors:
   given-names: "Anne"
   orcid: "https://orcid.org/0000-0003-1555-8261"
 title: "cytominer-database"
-version: 0.3.4
+version: 0.3.5
 url: "https://github.com/cytomining/cytominer-database"

--- a/cytominer_database/ingest.py
+++ b/cytominer_database/ingest.py
@@ -44,7 +44,7 @@ import warnings
 import zlib
 
 import pandas as pd
-import backports.tempfile
+import tempfile
 import sqlalchemy.exc
 from sqlalchemy import create_engine
 

--- a/cytominer_database/ingest_variable_engine.py
+++ b/cytominer_database/ingest_variable_engine.py
@@ -48,7 +48,7 @@ import csv
 import click
 import zlib
 import pandas as pd
-import backports.tempfile
+import tempfile
 import sqlalchemy.exc
 from sqlalchemy import create_engine
 import pyarrow

--- a/cytominer_database/load.py
+++ b/cytominer_database/load.py
@@ -3,7 +3,7 @@ import click
 import warnings
 import zlib
 import pandas as pd
-import backports.tempfile
+import tempfile
 import sqlalchemy.exc
 from sqlalchemy import create_engine
 import pyarrow

--- a/cytominer_database/tableSchema.py
+++ b/cytominer_database/tableSchema.py
@@ -4,7 +4,7 @@ import click
 import warnings
 import zlib
 import pandas as pd
-import backports.tempfile
+import tempfile
 import sqlalchemy.exc
 from sqlalchemy import create_engine
 import pyarrow

--- a/cytominer_database/write.py
+++ b/cytominer_database/write.py
@@ -3,7 +3,7 @@ import click
 import warnings
 import zlib
 import pandas as pd
-import backports.tempfile
+import tempfile
 import sqlalchemy.exc
 from sqlalchemy import create_engine
 import pyarrow

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setuptools.setup(
     install_requires=[
         "click>=6.7",
         "configparser>=3.5.0",
-        "csvkit==1.0.2",
+        "csvkit>=1.0.2,<2",
         "pandas>=0.20.3",
         "pyarrow",
     ],

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setuptools.setup(
     install_requires=[
         "click>=6.7",
         "configparser>=3.5.0",
-        "csvkit>=1.0.2",
+        "csvkit==1.0.2",
         "pandas>=0.20.3",
         "pyarrow",
     ],

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import setuptools
 
 project = "cytominer_database"
-version = "0.3.3"
+version = "0.3.5"
 
 # Note about authors:
 # setuptools makes it difficult to have multiple authors
@@ -30,11 +30,11 @@ setuptools.setup(
     packages=setuptools.find_packages(exclude=["tests", "doc"]),
     include_package_data=True,
     install_requires=[
-        "backports.tempfile>=1.0rc1",
         "click>=6.7",
         "configparser>=3.5.0",
         "csvkit>=1.0.2",
         "pandas>=0.20.3",
+        "pyarrow",
     ],
     license="BSD",
     url="https://github.com/cytomining/cytominer-database",

--- a/tests/commands/test_command_ingest.py
+++ b/tests/commands/test_command_ingest.py
@@ -2,7 +2,7 @@ import os.path
 import pandas as pd
 import pytest
 import click.testing
-import backports.tempfile
+import tempfile
 from sqlalchemy import create_engine
 
 import cytominer_database.command
@@ -34,7 +34,7 @@ def test_run(dataset, runner):
 
     opts += [dataset["data_dir"]]
 
-    with backports.tempfile.TemporaryDirectory() as temp_dir:
+    with tempfile.TemporaryDirectory() as temp_dir:
         sqlite_file = os.path.join(temp_dir, "test.db")
 
         opts += ["sqlite:///{}".format(sqlite_file)]
@@ -68,7 +68,7 @@ def test_run_variable_engine_default(dataset, runner):
     # SOURCE
     opts = [dataset["data_dir"]]
 
-    with backports.tempfile.TemporaryDirectory() as temp_dir:
+    with tempfile.TemporaryDirectory() as temp_dir:
         # TARGET
         sqlite_file = os.path.join(temp_dir, "test.db")
         opts += ["sqlite:///{}".format(sqlite_file)]
@@ -112,7 +112,7 @@ def test_run_variable_engine_sqlite(dataset, runner):
     CONFIG_CHOICE = "config_SQLite.ini"
     # SOURCE
     opts = [dataset["data_dir"]]
-    with backports.tempfile.TemporaryDirectory() as temp_dir:
+    with tempfile.TemporaryDirectory() as temp_dir:
         # TARGET
         sqlite_file = os.path.join(temp_dir, "test.db")
         opts += ["sqlite:///{}".format(sqlite_file)]
@@ -156,7 +156,7 @@ def test_run_variable_engine_parquet(dataset, runner):
     # SOURCE
     opts = [dataset["data_dir"]]
 
-    with backports.tempfile.TemporaryDirectory() as temp_dir:
+    with tempfile.TemporaryDirectory() as temp_dir:
         # TARGET
         # create output directory
         target = os.path.join(temp_dir, "test_parquet_output")
@@ -211,7 +211,7 @@ def test_run_defaults(cellpainting, runner):
 
     opts += [cellpainting["data_dir"]]
 
-    with backports.tempfile.TemporaryDirectory() as temp_dir:
+    with tempfile.TemporaryDirectory() as temp_dir:
         sqlite_file = os.path.join(temp_dir, "test.db")
 
         opts += ["sqlite:///{}".format(sqlite_file)]

--- a/tests/commands/test_command_ingest.py
+++ b/tests/commands/test_command_ingest.py
@@ -50,7 +50,7 @@ def test_run(dataset, runner):
             engine = create_engine(target)
             con = engine.connect()
 
-            df = pd.read_sql(sql=table_name, con=con, index_col=0)
+            df = pd.read_sql(sql=f"SELECT * FROM {table_name}", con=con)
 
             assert df.shape[0] == blob["nrows"]
             assert df.shape[1] == blob["ncols"] + 1
@@ -96,7 +96,7 @@ def test_run_variable_engine_default(dataset, runner):
             engine = create_engine(target)
             con = engine.connect()
 
-            df = pd.read_sql(sql=table_name, con=con, index_col=0)
+            df = pd.read_sql(sql=f"SELECT * FROM {table_name}", con=con)
 
             assert df.shape[0] == blob["nrows"]
             assert df.shape[1] == blob["ncols"] + 1
@@ -139,7 +139,7 @@ def test_run_variable_engine_sqlite(dataset, runner):
             engine = create_engine(target)
             con = engine.connect()
 
-            df = pd.read_sql(sql=table_name, con=con, index_col=0)
+            df = pd.read_sql(sql=f"SELECT * FROM {table_name}", con=con)
 
             assert df.shape[0] == blob["nrows"]
             assert df.shape[1] == blob["ncols"] + 1
@@ -227,7 +227,7 @@ def test_run_defaults(cellpainting, runner):
             engine = create_engine(target)
             con = engine.connect()
 
-            df = pd.read_sql(sql=table_name, con=con, index_col=0)
+            df = pd.read_sql(sql=f"SELECT * FROM {table_name}", con=con)
 
             assert df.shape[0] == blob["nrows"]
             assert df.shape[1] == blob["ncols"] + 1

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,7 +1,7 @@
 import os.path
 
 import pandas as pd
-import backports.tempfile
+import tempfile
 from sqlalchemy import create_engine
 
 import cytominer_database.ingest
@@ -27,7 +27,7 @@ def test_seed(dataset):
     if munge:
         cytominer_database.munge.munge(config_file, data_dir)
 
-    with backports.tempfile.TemporaryDirectory() as temp_dir:
+    with tempfile.TemporaryDirectory() as temp_dir:
         sqlite_file = os.path.join(temp_dir, "test.db")
 
         cytominer_database.ingest.seed(

--- a/tests/test_ingest_variable_engine.py
+++ b/tests/test_ingest_variable_engine.py
@@ -1,7 +1,7 @@
 import os
 
 import pandas as pd
-import backports.tempfile
+import tempfile
 from sqlalchemy import create_engine
 
 # import cytominer_database.ingest
@@ -24,7 +24,7 @@ def test_seed(dataset, config_choice):
     if munge:
         cytominer_database.munge.munge(config_path, data_dir)
 
-    with backports.tempfile.TemporaryDirectory() as temp_dir:
+    with tempfile.TemporaryDirectory() as temp_dir:
         # set up
         if engine_type == "Parquet":
             # create output directory

--- a/tests/test_munge.py
+++ b/tests/test_munge.py
@@ -1,9 +1,9 @@
 import os.path
 
-import backports.tempfile
+import tempfile
 import cytominer_database.munge
 import pandas as pd
-import pandas.util.testing
+from pandas.testing import assert_frame_equal
 
 
 def test_munge(dataset):
@@ -12,7 +12,7 @@ def test_munge(dataset):
 
     config_file = os.path.join(dataset["data_dir"], "config.ini")
 
-    with backports.tempfile.TemporaryDirectory() as temp_dir:
+    with tempfile.TemporaryDirectory() as temp_dir:
         valid_directories = cytominer_database.munge.munge(
             config_path=config_file, source=dataset["data_dir"], target=temp_dir
         )
@@ -32,4 +32,4 @@ def test_munge(dataset):
                     )
                 )
 
-                pandas.util.testing.assert_frame_equal(input_csv, output_csv)
+                assert_frame_equal(input_csv, output_csv)


### PR DESCRIPTION
This PR updates `cytominer-database` to remove the `backports.tempfile` dependency which sometimes can cause issues with Python versions and/or various architectures ([see here](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=1049301&view=logs&j=656edd35-690f-5c53-9ba3-09c10d0bea97&t=986b1512-c876-5f92-0d81-ba851554a0a3&l=1478) for a related error from a Pycytominer conda build). I've bumped the patch version as I feel we need to release this to PyPI and Conda-forge in order to work around any places where `backports.tempfile` may be causing issues (like the Pycytominer build mentioned).

Along the journey towards this PR I noticed that `csvkit>=2` has an API change which appears to cause many failing tests. As a result I set a maximum range to avoid these errors. Additionally, the Pandas SQL API had changed so I needed to make adjustments to tests in order for them to pass.

I ran tests with Python 3.8.19 to be cautious of any other remaining changes we might need to make for passing tests (given the deprecated status of this project). My steps for testing were the following (please let me know if I missed something):

- `pip install -e .`
- `pip install pytest`
- `python -m pytest`

References conda-forge/pycytominer-feedstock#11